### PR TITLE
Update scikit-learn to 0.19*

### DIFF
--- a/scipy-notebook/Dockerfile
+++ b/scipy-notebook/Dockerfile
@@ -25,7 +25,7 @@ RUN conda install --quiet --yes \
     'matplotlib=2.0*' \
     'scipy=0.19*' \
     'seaborn=0.7*' \
-    'scikit-learn=0.18*' \
+    'scikit-learn=0.19*' \
     'scikit-image=0.12*' \
     'sympy=1.0*' \
     'cython=0.25*' \


### PR DESCRIPTION
Release notes along with highlights can be found here http://scikit-learn.org/stable/whats_new.html#version-0-19-1